### PR TITLE
Remove boot completed permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,19 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission
+            android:name="android.permission.RECEIVE_BOOT_COMPLETED"
+            tools:node="remove"/>
    <application
         android:label="OpenHIIT"
         android:requestLegacyExternalStorage="true"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon">
+        <receiver
+            android:name="id.flutter.flutter_background_service.BootReceiver"
+            tools:replace="android:exported,android:enabled"
+            android:enabled="false"
+            android:exported="false" />
         <service
             android:name="id.flutter.flutter_background_service.BackgroundService"
             android:foregroundServiceType="mediaPlayback"


### PR DESCRIPTION
## Code changes

BOOT_COMPLETED permission is included in the flutter_background_service package but is not used in OpenHIIT. Removing due to the following warning:

> Apps targeting Android 15 or later cannot use BOOT_COMPLETED broadcast receivers to launch certain foreground service types. A version of your app that is currently in production crashes because it uses BOOT_COMPLETED broadcast receivers to start a restricted foreground service type. Update your app so it doesn't use broadcast receivers in this way.

## User-perceived changes
- None, potentially less crashes on Android 15 