### PR TITLE
Remove select button from color picker

### DIFF
--- a/integration_test/functions/functions.dart
+++ b/integration_test/functions/functions.dart
@@ -11,14 +11,6 @@ Future<void> loadApp(WidgetTester tester) async {
 Future<void> tapCreateTimerButton(WidgetTester tester) async {
   await tester.tap(find.byKey(const Key('create-timer')));
   await tester.pumpAndSettle();
-  // Tap the desired color (e.g., red)
-  final Size screenSize =
-      tester.view.physicalSize / tester.view.devicePixelRatio;
-  final Offset center = Offset(screenSize.width / 2, screenSize.height / 2);
-
-  // Tap the center of the screen
-  await tester.tapAt(center);
-  await tester.pumpAndSettle();
 }
 
 Future<void> pickTimerType(WidgetTester tester, bool isWorkout) async {
@@ -34,7 +26,10 @@ Future<void> enterTimerName(WidgetTester tester, String name) async {
 Future<void> pickColor(WidgetTester tester) async {
   await tester.tap(find.byKey(const Key('color-picker')));
   await tester.pumpAndSettle();
-  await tester.tap(find.text('Select'));
+  final Size screenSize =
+      tester.view.physicalSize / tester.view.devicePixelRatio;
+  final Offset center = Offset(screenSize.width / 2, screenSize.height / 2);
+  await tester.tapAt(center);
   await tester.pumpAndSettle();
 }
 

--- a/integration_test/functions/functions.dart
+++ b/integration_test/functions/functions.dart
@@ -11,6 +11,14 @@ Future<void> loadApp(WidgetTester tester) async {
 Future<void> tapCreateTimerButton(WidgetTester tester) async {
   await tester.tap(find.byKey(const Key('create-timer')));
   await tester.pumpAndSettle();
+  // Tap the desired color (e.g., red)
+  final Size screenSize =
+      tester.view.physicalSize / tester.view.devicePixelRatio;
+  final Offset center = Offset(screenSize.width / 2, screenSize.height / 2);
+
+  // Tap the center of the screen
+  await tester.tapAt(center);
+  await tester.pumpAndSettle();
 }
 
 Future<void> pickTimerType(WidgetTester tester, bool isWorkout) async {

--- a/lib/widgets/form_widgets/create_form.dart
+++ b/lib/widgets/form_widgets/create_form.dart
@@ -39,35 +39,20 @@ class CreateFormState extends State<CreateForm> {
     /// allows the user to select a color.
     ///
     void pickColor() {
-      Color selectedColor = Color(widget.timer.color);
       showDialog(
         context: context,
         builder: (context) {
           return AlertDialog(
             content: MaterialColorPicker(
               onMainColorChange: (value) {
-                selectedColor = value as Color;
+                setState(() {
+                  widget.timer.color = (value as Color).value;
+                });
+                Navigator.pop(context);
               },
               allowShades: false,
-              selectedColor: selectedColor,
+              selectedColor: Color(widget.timer.color),
             ),
-            actions: [
-              TextButton(
-                onPressed: () {
-                  Navigator.pop(context);
-                },
-                child: const Text('Cancel'),
-              ),
-              TextButton(
-                onPressed: () {
-                  Navigator.pop(context);
-                  setState(() {
-                    widget.timer.color = selectedColor.value;
-                  });
-                },
-                child: const Text('Select'),
-              ),
-            ],
           );
         },
       );


### PR DESCRIPTION
## Changes

- Removed select and cancel buttons from the color picker.

## Testing

- [x] When a color is tapped, the dialog closes and the color is correctly set.
- [x] The dialog closes when anywhere outside of the dialog is tapped.