### PR TITLE
Fix UI element layout in the general tab

### DIFF
--- a/lib/features/edit_timer/ui/edit_timer.dart
+++ b/lib/features/edit_timer/ui/edit_timer.dart
@@ -432,7 +432,10 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
 
   Widget _buildLandscapeLayout() {
     return Scaffold(
-      appBar: AppBar(),
+      resizeToAvoidBottomInset: false,
+      appBar: AppBar(
+        toolbarHeight: 1.0,
+      ),
       body: Row(
         children: [
           NavigationRail(

--- a/lib/features/edit_timer/ui/widgets/tabs/general_tab/general_tab.dart
+++ b/lib/features/edit_timer/ui/widgets/tabs/general_tab/general_tab.dart
@@ -38,6 +38,7 @@ class GeneralTab extends StatelessWidget {
 
     return SingleChildScrollView(
         controller: scrollController,
+        physics: const ClampingScrollPhysics(),
         child: Column(
           children: [
             Padding(
@@ -379,7 +380,7 @@ class GeneralTab extends StatelessWidget {
                 ),
               ),
             ),
-            SizedBox(height: 80),
+            SizedBox(height: 100),
           ],
         ));
   }


### PR DESCRIPTION
## Description

- Adds more bottom padding to the general tab so the start button does not cover the break time.
- Sets `ClampingScrollPhysics` for the general tab. Improves scrolling the form on iOS.
- Decreases appbar height for the general tab landscape.
- Disable `resizeToAvoidBottomInset` on landscape to avoid overflow in the navrail.

## Motivation and Context

<!-- Please replace "<ISSUE_NUMBER>" with an associated issue number if applicable. -->
Resolves #264 

## How Has This Been Tested?

*Please describe in detail how you tested your changes. Provide instructions for testing this PR.*

- Edit or create a new timer.
- Scrolled to bottom of the general tab until the start button is under the break time.
- Rotate to landscape and ensure all margins are correct when scrolled to the top and bottom of the general tab form. 

### Tested Platforms

*List all platforms where you have tested this PR.
If you haven’t tested on a platform that could be affected (e.g., iOS), please note it so maintainers know it still needs testing.*

Platform 1: iOS 18.4, Apple iPhone 16 Pro
Platform 1: Android 13, Pixel 4a

## Screenshots (optional)


<img width="500" alt="Screenshot 2025-11-06 at 8 41 59 PM" src="https://github.com/user-attachments/assets/0022d1f5-5e85-4110-a213-0ffbbac79611" />


<img width="500" alt="Screenshot 2025-11-06 at 8 51 16 PM" src="https://github.com/user-attachments/assets/4d3be417-86c0-45ef-991e-df3d0ac10774" />


<img width="500" alt="Screenshot 2025-11-06 at 8 51 29 PM" src="https://github.com/user-attachments/assets/b347bc6e-0d99-4bd3-b1d8-b26ae30533c9" />

## Types of changes

<!-- Please check all that apply. -->

- [ ] Chore (changes that do not affect docs or app behavior)
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update (changes to docs or screenshots)

## Checklist

- [x] I have read the Contributing guide: https://github.com/a-mabe/OpenHIIT/tree/main?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] I have made corresponding changes to the integration tests (if needed)

## Additional Notes
*Add any other context about the pull request here.*