### PR TITLE
Hide export if timer list is empty

### DIFF
--- a/lib/features/home/ui/home.dart
+++ b/lib/features/home/ui/home.dart
@@ -120,16 +120,20 @@ class _ListTimersPageState extends State<ListTimersPage> {
           top: false,
           child: CustomBottomAppBar(
             children: [
-              Spacer(),
-              NavBarIconButton(
-                icon: Icons.upload,
-                label: 'Export',
-                fontSize: 11,
-                spacing: 0,
-                verticalPadding: 0,
-                onPressed: () {
-                  onExportPressed(context, timerProvider.timers);
-                },
+              Visibility(
+                  visible: timerProvider.timers.isNotEmpty, child: Spacer()),
+              Visibility(
+                visible: timerProvider.timers.isNotEmpty,
+                child: NavBarIconButton(
+                  icon: Icons.upload,
+                  label: 'Export',
+                  fontSize: 11,
+                  spacing: 0,
+                  verticalPadding: 0,
+                  onPressed: () {
+                    onExportPressed(context, timerProvider.timers);
+                  },
+                ),
               ),
               Spacer(),
               NavBarIconButton(
@@ -273,17 +277,21 @@ class _ListTimersPageState extends State<ListTimersPage> {
                   },
                 ),
               ),
-              SizedBox(height: 12),
-              Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 15),
-                  child: NavBarIconButton(
-                      icon: Icons.upload,
-                      iconSize: 25,
-                      label: 'Export',
-                      verticalPadding: 8,
-                      onPressed: () {
-                        onExportPressed(context, timerProvider.timers);
-                      })),
+              Visibility(
+                  visible: timerProvider.timers.isNotEmpty,
+                  child: SizedBox(height: 12)),
+              Visibility(
+                  visible: timerProvider.timers.isNotEmpty,
+                  child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 15),
+                      child: NavBarIconButton(
+                          icon: Icons.upload,
+                          iconSize: 25,
+                          label: 'Export',
+                          verticalPadding: 8,
+                          onPressed: () {
+                            onExportPressed(context, timerProvider.timers);
+                          }))),
               SizedBox(height: 12),
               Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 15),


### PR DESCRIPTION
## Description

Export button is now hidden if there are no saved timers.

## Motivation and Context

Resolves #265 

## How Has This Been Tested?

- Opened fresh app install.
- Export button not shown as there are no saved timers.
- Create a timer.
- Export button now available.
- Delete only timer.
- Export button now hidden.

### Tested Platforms

Android 13, Pixel 4a

## Screenshots (optional)

## Types of changes

<!-- Please check all that apply. -->

- [ ] Chore (changes that do not affect docs or app behavior)
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update (changes to docs or screenshots)

## Checklist

- [x] I have read the Contributing guide: https://github.com/a-mabe/OpenHIIT/tree/main?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] I have made corresponding changes to the integration tests (if needed)

## Additional Notes
*Add any other context about the pull request here.*