### PR TITLE
Shrink minutes/seconds popup padding

### DIFF
--- a/lib/features/edit_timer/ui/widgets/tabs/general_tab/general_tab.dart
+++ b/lib/features/edit_timer/ui/widgets/tabs/general_tab/general_tab.dart
@@ -118,50 +118,46 @@ class GeneralTab extends StatelessWidget {
                       content: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Container(
-                            padding: const EdgeInsets.all(16.0),
-                            child: Column(
-                              children: [
-                                Text(
-                                  "Minutes View",
-                                  style: TextStyle(
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.bold,
-                                  ),
+                          SizedBox(height: 5),
+                          Column(
+                            children: [
+                              Text(
+                                "Minutes View",
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.bold,
                                 ),
-                                SizedBox(height: 10),
-                                Text(
-                                  "1:42",
-                                  style: TextStyle(
-                                    fontSize: 48,
-                                    fontWeight: FontWeight.bold,
-                                  ),
+                              ),
+                              SizedBox(height: 5),
+                              Text(
+                                "1:42",
+                                style: TextStyle(
+                                  fontSize: 34,
+                                  fontWeight: FontWeight.bold,
                                 ),
-                              ],
-                            ),
+                              ),
+                            ],
                           ),
                           Divider(color: Colors.grey.shade800, thickness: 1),
-                          Container(
-                            padding: const EdgeInsets.all(16.0),
-                            child: Column(
-                              children: [
-                                Text(
-                                  "Seconds View",
-                                  style: TextStyle(
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.bold,
-                                  ),
+                          SizedBox(height: 5),
+                          Column(
+                            children: [
+                              Text(
+                                "Seconds View",
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.bold,
                                 ),
-                                SizedBox(height: 10),
-                                Text(
-                                  "102s",
-                                  style: TextStyle(
-                                    fontSize: 48,
-                                    fontWeight: FontWeight.bold,
-                                  ),
+                              ),
+                              SizedBox(height: 5),
+                              Text(
+                                "102s",
+                                style: TextStyle(
+                                  fontSize: 34,
+                                  fontWeight: FontWeight.bold,
                                 ),
-                              ],
-                            ),
+                              ),
+                            ],
                           ),
                         ],
                       ),


### PR DESCRIPTION
## Description

Fixes overflow that occurs on the minutes/seconds popup on landscape orientation.

## Motivation and Context

Fixes UI overflow.

## How Has This Been Tested?

1. Select New timer.
2. Change to landscape orientation.
3. Tap Timer Display.
4. Popup should not have overflow.

### Tested Platforms

Platform 1: iOS 17.4, iPhone 13 mini (for the small screen size)

## Screenshots (optional)

<img width="444" height="533" alt="Screenshot 2025-11-19 at 6 47 04 PM" src="https://github.com/user-attachments/assets/d194186b-7e72-4241-9b88-e6843cc66811" />

## Types of changes

<!-- Please check all that apply. -->

- [ ] Chore (changes that do not affect docs or app behavior)
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update (changes to docs or screenshots)

## Checklist

- [x] I have read the Contributing guide: https://github.com/a-mabe/OpenHIIT/tree/main?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] I have made corresponding changes to the integration tests (if needed)

## Additional Notes
*Add any other context about the pull request here.*