### PR TITLE
Wrap entire ListTimersPage in a single FutureBuilder.

### DIFF
--- a/lib/features/home/ui/home.dart
+++ b/lib/features/home/ui/home.dart
@@ -76,12 +76,15 @@ class _ListTimersPageState extends State<ListTimersPage> {
             return Scaffold(
               extendBodyBehindAppBar: true,
               extendBody: true,
-              appBar: isLandscape && isTablet
+              appBar: isTablet && isLandscape
                   ? PreferredSize(
-                      preferredSize: const Size.fromHeight(40.0),
-                      child: AppBar(toolbarHeight: 1.0, elevation: 0),
+                      preferredSize: Size.fromHeight(40.0),
+                      child: AppBar(
+                        toolbarHeight: 1.0,
+                        elevation: 0,
+                      ),
                     )
-                  : ListTimersAppBar(),
+                  : (!isLandscape ? ListTimersAppBar() : null),
               body: isLandscape || isTablet
                   ? Row(
                       children: [


### PR DESCRIPTION
## Description

Wrap entire ListTimersPage in a single FutureBuilder

- Ensures portrait, landscape, bottom nav, and nav rail use the same snapshot.
- Removes multiple FutureBuilders and improper visibility logic.

## Motivation and Context

There was a race condition where Export would sometimes not appear on the home screen.

## How Has This Been Tested?

- Saved timers.
- Closed app and then reopened so timers and Export button would reload.

### Tested Platforms

Platform 1: Android 13, Pixel 3a

## Screenshots (optional)

## Types of changes

<!-- Please check all that apply. -->

- [ ] Chore (changes that do not affect docs or app behavior)
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update (changes to docs or screenshots)

## Checklist

- [x] I have read the Contributing guide: https://github.com/a-mabe/OpenHIIT/tree/main?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] I have made corresponding changes to the integration tests (if needed)

## Additional Notes
*Add any other context about the pull request here.*