### PR TITLE
chore: Improve wording on timer completion screen

### DIFF
--- a/lib/features/run_timer/widgets/timer_complete.dart
+++ b/lib/features/run_timer/widgets/timer_complete.dart
@@ -88,7 +88,7 @@ class TimerCompleteState extends State<TimerComplete> {
                     fontWeight: FontWeight.bold),
               ),
               Text(
-                'Completed the ${widget.timerName} timer!',
+                'Completed: ${widget.timerName}',
                 textAlign: TextAlign.center,
                 style: TextStyle(
                     color: Colors.white,


### PR DESCRIPTION
## Description

The wording was: "Completed the timer!"

Timer name may not fit into that sentence. Changed the wording to be more generic: "Timer completed: "

## Motivation and Context

Resolves #288

## How Has This Been Tested?

Completed timer and verified text.

### Tested Platforms

- Platform 1: Android 13, Pixel 4a

## Screenshots (optional)

## Types of changes

<!-- Please check all that apply. -->

- [x] Chore (changes that do not affect docs or app behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update (changes to docs or screenshots)

## Checklist

- [x] I have read the Contributing guide: https://github.com/a-mabe/OpenHIIT/tree/main?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] I have made corresponding changes to the integration tests (if needed)

## Additional Notes
*Add any other context about the pull request here.*