### PR TITLE
chore: Cleanup unused code

### DIFF
--- a/lib/features/home/ui/home.dart
+++ b/lib/features/home/ui/home.dart
@@ -54,19 +54,6 @@ class _ListTimersPageState extends State<ListTimersPage> {
   Future<void> _handleWhatsNew() async {
     const currentVersion = WhatsNewData.version;
 
-    /// Uncomment the following lines once shared preferences for versioning are added.
-    ///
-    // final firstLaunch = await WhatsNewService.isFirstLaunch();
-
-    // if (firstLaunch) {
-    //   // Do not show the popup for brand-new users
-    //   logger.i("First launch detected, skipping What's New dialog.");
-    //   await WhatsNewService.markShown(currentVersion);
-    //   return;
-    // }
-
-    logger.i("Not first launch, checking if What's New should be shown.");
-
     // At this point the user has launched before
     if (await WhatsNewService.shouldShow(currentVersion)) {
       final items = WhatsNewData.items;

--- a/lib/features/whats_new/utils/whats_new_service.dart
+++ b/lib/features/whats_new/utils/whats_new_service.dart
@@ -2,20 +2,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class WhatsNewService {
   static const _versionKey = 'last_whats_new_version';
-  static const _firstLaunchKey = 'has_launched_before';
-
-  /// Returns true if this is the user's first app launch.
-  static Future<bool> isFirstLaunch() async {
-    final prefs = await SharedPreferences.getInstance();
-    final hasLaunched = prefs.getBool(_firstLaunchKey) ?? false;
-
-    if (!hasLaunched) {
-      await prefs.setBool(_firstLaunchKey, true);
-      return true; // first launch
-    }
-
-    return false; // user has launched before
-  }
 
   /// Checks if the popup should show for this version.
   static Future<bool> shouldShow(String version) async {


### PR DESCRIPTION
## Description

Clean up commented code. Keeping the current behavior of showing the What's New popup on initial install. This is to avoid any dependency on the user installing version 1.6.0 specifically.

## Motivation and Context

Resolves #287 

## How Has This Been Tested?

Verified behavior is unchanged.

### Tested Platforms

Platform 1: Android 13, Pixel 4a

## Screenshots (optional)

## Types of changes

<!-- Please check all that apply. -->

- [x] Chore (changes that do not affect docs or app behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update (changes to docs or screenshots)

## Checklist

- [x] I have read the Contributing guide: https://github.com/a-mabe/OpenHIIT/tree/main?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] I have made corresponding changes to the integration tests (if needed)

## Additional Notes
*Add any other context about the pull request here.*