### PR TITLE
refactor: restarts as unit less

### DIFF
--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -53,6 +53,7 @@ const createTimerTableQuery = '''
         totalTime INTEGER,
         intervals INTEGER,
         activeIntervals INTEGER,
+        restarts INTEGER,
         activities TEXT,
         showMinutes INTEGER,
         color INTEGER
@@ -68,8 +69,7 @@ const createTimeSettingsTableQuery = '''
         restTime INTEGER,
         breakTime INTEGER,
         warmupTime INTEGER,
-        cooldownTime INTEGER,
-        restarts INTEGER
+        cooldownTime INTEGER
       )
     ''';
 

--- a/lib/core/models/timer_time_settings.dart
+++ b/lib/core/models/timer_time_settings.dart
@@ -9,7 +9,6 @@ class TimerTimeSettings {
   int warmupTime;
   int cooldownTime;
   int getReadyTime;
-  int restarts;
 
   TimerTimeSettings(
       {required this.id,
@@ -19,8 +18,7 @@ class TimerTimeSettings {
       required this.breakTime,
       required this.warmupTime,
       required this.cooldownTime,
-      required this.getReadyTime,
-      required this.restarts});
+      required this.getReadyTime});
 
   TimerTimeSettings.empty()
       : id = "",
@@ -30,8 +28,7 @@ class TimerTimeSettings {
         breakTime = 0,
         warmupTime = 0,
         cooldownTime = 0,
-        getReadyTime = 10,
-        restarts = 0;
+        getReadyTime = 10;
 
   TimerTimeSettings copyWith(
     Map<String, int> map, {
@@ -46,7 +43,6 @@ class TimerTimeSettings {
       warmupTime: updates?['warmupTime'] ?? warmupTime,
       cooldownTime: updates?['cooldownTime'] ?? cooldownTime,
       getReadyTime: updates?['getReadyTime'] ?? getReadyTime,
-      restarts: updates?['restarts'] ?? restarts,
     );
   }
 
@@ -62,7 +58,6 @@ class TimerTimeSettings {
       warmupTime: warmupTime,
       cooldownTime: cooldownTime,
       getReadyTime: getReadyTime,
-      restarts: restarts,
     );
   }
 
@@ -76,7 +71,6 @@ class TimerTimeSettings {
       'warmupTime': warmupTime,
       'cooldownTime': cooldownTime,
       'getReadyTime': getReadyTime,
-      'restarts': restarts,
     };
   }
 
@@ -88,8 +82,7 @@ class TimerTimeSettings {
         breakTime = map['breakTime'] ?? 0,
         warmupTime = map['warmupTime'] ?? 0,
         cooldownTime = map['cooldownTime'] ?? 0,
-        getReadyTime = map['getReadyTime'] ?? 0,
-        restarts = map['restarts'] ?? 0;
+        getReadyTime = map['getReadyTime'] ?? 0;
 
   Map<String, dynamic> toJson() {
     return {
@@ -101,7 +94,6 @@ class TimerTimeSettings {
       'warmupTime': warmupTime,
       'cooldownTime': cooldownTime,
       'getReadyTime': getReadyTime,
-      'restarts': restarts,
     };
   }
 
@@ -115,12 +107,11 @@ class TimerTimeSettings {
       warmupTime: json['warmupTime'] ?? 0,
       cooldownTime: json['cooldownTime'] ?? 0,
       getReadyTime: json['getReadyTime'] ?? 0,
-      restarts: json['restarts'] ?? 0,
     );
   }
 
   @override
   String toString() {
-    return 'TimerTimeSettings{id: $id, timerId: $timerId, workTime: $workTime, restTime: $restTime, breakTime: $breakTime, warmupTime: $warmupTime, cooldownTime: $cooldownTime, getReadyTime: $getReadyTime, restarts: $restarts}';
+    return 'TimerTimeSettings{id: $id, timerId: $timerId, workTime: $workTime, restTime: $restTime, breakTime: $breakTime, warmupTime: $warmupTime, cooldownTime: $cooldownTime, getReadyTime: $getReadyTime}';
   }
 }

--- a/lib/core/models/timer_type.dart
+++ b/lib/core/models/timer_type.dart
@@ -11,6 +11,7 @@ class TimerType {
   int totalTime;
   int intervals;
   int activeIntervals;
+  int restarts;
   List<String> activities;
   int showMinutes;
   int color;
@@ -26,6 +27,7 @@ class TimerType {
     this.totalTime = 0,
     this.intervals = 0,
     this.activeIntervals = 0,
+    this.restarts = 0,
     this.activities = const [],
     this.showMinutes = 0,
     this.color = 4280391411, // blue
@@ -40,6 +42,7 @@ class TimerType {
         totalTime = 0,
         intervals = 0,
         activeIntervals = 0,
+        restarts = 0,
         activities = [],
         showMinutes = 0,
         color = 4280391411; // blue
@@ -54,6 +57,7 @@ class TimerType {
       totalTime: totalTime,
       intervals: intervals,
       activeIntervals: activeIntervals,
+      restarts: restarts,
       activities: activities,
       showMinutes: showMinutes,
       color: color,
@@ -72,6 +76,7 @@ class TimerType {
       totalTime: totalTime,
       intervals: intervals,
       activeIntervals: activeIntervals,
+      restarts: restarts,
       activities: activities,
       showMinutes: showMinutes,
       color: color,
@@ -86,6 +91,7 @@ class TimerType {
       'totalTime': totalTime,
       'intervals': intervals,
       'activeIntervals': activeIntervals,
+      'restarts': restarts,
       'activities': jsonEncode(activities),
       'showMinutes': showMinutes,
       'color': color,
@@ -101,6 +107,7 @@ class TimerType {
         totalTime = map['totalTime'] ?? 0,
         intervals = map['intervals'] ?? 0,
         activeIntervals = map['activeIntervals'] ?? 0,
+        restarts = map['restarts'] ?? 0,
         activities = map['activities'] != null
             ? List<String>.from(jsonDecode(map['activities']))
             : [],
@@ -125,6 +132,7 @@ class TimerType {
       totalTime: updates['totalTime'] ?? totalTime,
       intervals: updates['intervals'] ?? intervals,
       activeIntervals: updates['activeIntervals'] ?? activeIntervals,
+      restarts: updates['restarts'] ?? restarts,
       activities: updates['activities'] ?? activities,
       showMinutes: updates['showMinutes'] ?? showMinutes,
       color: updates['color'] ?? color,
@@ -139,6 +147,7 @@ class TimerType {
       'totalTime': totalTime,
       'intervals': intervals,
       'activeIntervals': activeIntervals,
+      'restarts': restarts,
       'activities': activities,
       'showMinutes': showMinutes,
       'color': color,
@@ -158,6 +167,7 @@ class TimerType {
       totalTime: json['totalTime'] ?? 0,
       intervals: json['intervals'] ?? 0,
       activeIntervals: json['activeIntervals'] ?? 0,
+      restarts: json['restarts'] ?? 0,
       activities: (json['activities'] != null && json['activities'] is List)
           ? List<String>.from(json['activities'])
           : [],
@@ -176,6 +186,6 @@ class TimerType {
 
   @override
   String toString() {
-    return 'TimerType{id: $id, name: $name, totalTime: $totalTime, intervals: $intervals, showMinutes: $showMinutes, activeIntervals: $activeIntervals, activities: $activities, color: $color, timerIndex: $timerIndex}';
+    return 'TimerType{id: $id, name: $name, totalTime: $totalTime, intervals: $intervals, showMinutes: $showMinutes, activeIntervals: $activeIntervals, restarts: $restarts, activities: $activities, color: $color, timerIndex: $timerIndex}';
   }
 }

--- a/lib/core/providers/timer_creation_provider/timer_creation_provider.dart
+++ b/lib/core/providers/timer_creation_provider/timer_creation_provider.dart
@@ -10,7 +10,7 @@ class TimerCreationProvider extends ChangeNotifier {
   bool _isEdited = false;
   bool get isEdited => _isEdited;
 
-  bool get breakEnabled => _timer.timeSettings.restarts > 0;
+  bool get breakEnabled => _timer.restarts > 0;
 
   void markEdited() {
     if (!_isEdited) {
@@ -72,6 +72,14 @@ class TimerCreationProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void setRestarts(int restarts) {
+    _timer = _timer.copyWith({
+      'restarts': restarts,
+    });
+    _isEdited = true;
+    notifyListeners();
+  }
+
   void setTotalTime(int totalTime) {
     _timer = _timer.copyWith({
       'totalTime': totalTime,
@@ -87,7 +95,6 @@ class TimerCreationProvider extends ChangeNotifier {
     int? warmupTime,
     int? cooldownTime,
     int? getReadyTime,
-    int? restarts,
   }) {
     _timer.timeSettings = _timer.timeSettings.copyWith({}, updates: {
       if (workTime != null) 'workTime': workTime,
@@ -96,7 +103,6 @@ class TimerCreationProvider extends ChangeNotifier {
       if (warmupTime != null) 'warmupTime': warmupTime,
       if (cooldownTime != null) 'cooldownTime': cooldownTime,
       if (getReadyTime != null) 'getReadyTime': getReadyTime,
-      if (restarts != null) 'restarts': restarts,
     });
     _timer = _timer.copyWith({
       'timeSettings': _timer.timeSettings,

--- a/lib/core/providers/timer_provider/migrations/migration_1.dart
+++ b/lib/core/providers/timer_provider/migrations/migration_1.dart
@@ -41,7 +41,6 @@ TimerType migrateToTimer(Workout workout, bool update) {
         warmupTime: workout.warmupTime,
         cooldownTime: workout.cooldownTime,
         getReadyTime: workout.getReadyTime,
-        restarts: workout.iterations,
       ),
       soundSettings: TimerSoundSettings(
         id: Uuid().v1(),
@@ -59,6 +58,7 @@ TimerType migrateToTimer(Workout workout, bool update) {
       color: workout.colorInt,
       intervals: totalIntervals,
       activeIntervals: workout.numExercises,
+      restarts: workout.iterations,
       activities: workout.exercises != ""
           ? List<String>.from(jsonDecode(workout.exercises))
           : [],

--- a/lib/core/utils/interval_calculation.dart
+++ b/lib/core/utils/interval_calculation.dart
@@ -60,8 +60,8 @@ List<IntervalType> generateIntervalsFromTimer(TimerType timer,
     );
   }
 
-  int iterations = (timer.timeSettings.restarts > 0 && !singleIteration)
-      ? timer.timeSettings.restarts + 1
+  int iterations = (timer.restarts > 0 && !singleIteration)
+      ? timer.restarts + 1
       : 1;
 
   for (int iteration = 0; iteration < iterations; iteration++) {
@@ -88,7 +88,7 @@ List<IntervalType> generateIntervalsFromTimer(TimerType timer,
       }
     }
 
-    if (iteration < timer.timeSettings.restarts) {
+    if (iteration < timer.restarts) {
       addInterval(
         id: Uuid().v4(),
         name: timer.timeSettings.breakTime > 0 ? "Break" : "Rest",

--- a/lib/features/edit_timer/ui/edit_timer.dart
+++ b/lib/features/edit_timer/ui/edit_timer.dart
@@ -30,6 +30,7 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
 
   final nameController = TextEditingController();
   final activeIntervalsController = TextEditingController();
+  final restartsController = TextEditingController();
   Map<String, UnitNumberInputController> timeSettingsControllers = {};
   final List<TextEditingController> editorTabTextControllers = [];
   final formKey = GlobalKey<FormState>();
@@ -90,6 +91,8 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
     nameController.text = timer.name;
     activeIntervalsController.text =
         timer.activeIntervals == 0 ? '' : timer.activeIntervals.toString();
+    restartsController.text =
+        timer.restarts == 0 ? '' : timer.restarts.toString();
 
     timeSettingsControllers = {
       'work': UnitNumberInputController(
@@ -112,10 +115,6 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
         initialSeconds: ts.cooldownTime,
         startInMinutesMode: showMinutes,
       ),
-      'restarts': UnitNumberInputController(
-        initialSeconds: ts.restarts,
-        startInMinutesMode: false,
-      ),
       'break': UnitNumberInputController(
         initialSeconds: ts.breakTime,
         startInMinutesMode: showMinutes,
@@ -129,6 +128,7 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
     _scrollController.dispose();
     nameController.dispose();
     activeIntervalsController.dispose();
+    restartsController.dispose();
     for (var controller in timeSettingsControllers.values) {
       controller.dispose();
     }
@@ -278,6 +278,7 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
             GeneralTab(
               nameController: nameController,
               activeIntervalsController: activeIntervalsController,
+              restartsController: restartsController,
               timeSettingsControllers: timeSettingsControllers,
               editing: editing,
               onEdited: setButtonState,

--- a/lib/features/edit_timer/ui/widgets/tabs/editor_tab/editor_tab.dart
+++ b/lib/features/edit_timer/ui/widgets/tabs/editor_tab/editor_tab.dart
@@ -98,7 +98,7 @@ class EditorTab extends StatelessWidget {
                             const SizedBox(
                                 width: 8), // spacing between icon and text
                             Text(
-                              "Repeat for ${provider.timer.timeSettings.restarts}x",
+                              "Repeat for ${provider.timer.restarts}x",
                               style: const TextStyle(
                                 fontSize: 20,
                                 fontWeight: FontWeight.bold,

--- a/lib/features/edit_timer/ui/widgets/tabs/general_tab/general_tab.dart
+++ b/lib/features/edit_timer/ui/widgets/tabs/general_tab/general_tab.dart
@@ -10,6 +10,7 @@ import 'package:unit_number_input/unit_number_input.dart';
 class GeneralTab extends StatelessWidget {
   final TextEditingController nameController;
   final TextEditingController activeIntervalsController;
+  final TextEditingController restartsController;
   final Map<String, UnitNumberInputController> timeSettingsControllers;
   final ValueChanged<StartSaveState> onEdited;
   final ValueChanged<bool> onUnitToggle;
@@ -21,6 +22,7 @@ class GeneralTab extends StatelessWidget {
       {super.key,
       required this.nameController,
       required this.activeIntervalsController,
+      required this.restartsController,
       required this.timeSettingsControllers,
       required this.onEdited,
       required this.onUnitToggle,
@@ -326,17 +328,23 @@ class GeneralTab extends StatelessWidget {
             ListTile(
               key: const Key("restarts"),
               title: const Text('Restarts'),
-              subtitle: Text('Optional'),
+              subtitle: Text('Optional, # of restarts'),
               leading: const Icon(Icons.replay),
-              trailing: FittedBox(
-                fit: BoxFit.contain,
-                child: UnitNumberInput(
-                  controller: timeSettingsControllers['restarts']!,
-                  prefill: editing,
-                  enableMinutesToggle: false,
-                  valueRequired: false,
+              trailing: SizedBox(
+                width: 80,
+                child: TextFormField(
+                  controller: restartsController,
+                  decoration: inputDecoration,
+                  maxLength: 3,
+                  style: const TextStyle(fontSize: 30),
+                  textAlign: TextAlign.end,
+                  keyboardType: TextInputType.number,
                   onChanged: (value) {
-                    provider.setTimerTimeSettingPart(restarts: value);
+                    if (value.isEmpty) {
+                      provider.setRestarts(0);
+                    } else {
+                      provider.setRestarts(int.tryParse(value) ?? 0);
+                    }
                     onEdited(StartSaveState.save);
                     Log.debug("Restarts time changed to $value");
 


### PR DESCRIPTION
## Description

restarts should show as unit-less number not as time (with seconds). So I moved `restarts` out of `TimerTimeSettings` one level up to `Timer`. I did this in the way activeIntervals is coded.

## Motivation and Context

Resolves #300

## How Has This Been Tested?

WIP

### Tested Platforms

*List all platforms where you have tested this PR.
If you haven’t tested on a platform that could be affected (e.g., iOS), please note it so maintainers know it still needs testing.*

*Platform 1: iOS 16.3, Apple iPhone 12*

## Screenshots (optional)

## Types of changes

- [ ] Chore (changes that do not affect docs or app behavior)
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update (changes to docs or screenshots)

## Checklist

- [x] I have read the Contributing guide: https://github.com/a-mabe/OpenHIIT/tree/main?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if needed) -> not needed as no functional change
- [ ] I have made corresponding changes to the integration tests (if needed) -> not needed