### PR TITLE
chore: UI restarts as number not time unit

### DIFF
--- a/lib/features/edit_timer/ui/edit_timer.dart
+++ b/lib/features/edit_timer/ui/edit_timer.dart
@@ -30,6 +30,7 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
 
   final nameController = TextEditingController();
   final activeIntervalsController = TextEditingController();
+  final restartsController = TextEditingController();
   Map<String, UnitNumberInputController> timeSettingsControllers = {};
   final List<TextEditingController> editorTabTextControllers = [];
   final formKey = GlobalKey<FormState>();
@@ -90,6 +91,8 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
     nameController.text = timer.name;
     activeIntervalsController.text =
         timer.activeIntervals == 0 ? '' : timer.activeIntervals.toString();
+    restartsController.text =
+        ts.restarts == 0 ? '' : ts.restarts.toString();
 
     timeSettingsControllers = {
       'work': UnitNumberInputController(
@@ -112,10 +115,6 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
         initialSeconds: ts.cooldownTime,
         startInMinutesMode: showMinutes,
       ),
-      'restarts': UnitNumberInputController(
-        initialSeconds: ts.restarts,
-        startInMinutesMode: false,
-      ),
       'break': UnitNumberInputController(
         initialSeconds: ts.breakTime,
         startInMinutesMode: showMinutes,
@@ -129,6 +128,7 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
     _scrollController.dispose();
     nameController.dispose();
     activeIntervalsController.dispose();
+    restartsController.dispose();
     for (var controller in timeSettingsControllers.values) {
       controller.dispose();
     }
@@ -278,6 +278,7 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
             GeneralTab(
               nameController: nameController,
               activeIntervalsController: activeIntervalsController,
+              restartsController: restartsController,
               timeSettingsControllers: timeSettingsControllers,
               editing: editing,
               onEdited: setButtonState,

--- a/lib/features/edit_timer/ui/widgets/tabs/general_tab/general_tab.dart
+++ b/lib/features/edit_timer/ui/widgets/tabs/general_tab/general_tab.dart
@@ -10,6 +10,7 @@ import 'package:unit_number_input/unit_number_input.dart';
 class GeneralTab extends StatelessWidget {
   final TextEditingController nameController;
   final TextEditingController activeIntervalsController;
+  final TextEditingController restartsController;
   final Map<String, UnitNumberInputController> timeSettingsControllers;
   final ValueChanged<StartSaveState> onEdited;
   final ValueChanged<bool> onUnitToggle;
@@ -21,6 +22,7 @@ class GeneralTab extends StatelessWidget {
       {super.key,
       required this.nameController,
       required this.activeIntervalsController,
+      required this.restartsController,
       required this.timeSettingsControllers,
       required this.onEdited,
       required this.onUnitToggle,
@@ -326,17 +328,23 @@ class GeneralTab extends StatelessWidget {
             ListTile(
               key: const Key("restarts"),
               title: const Text('Restarts'),
-              subtitle: Text('Optional'),
+              subtitle: Text('Optional, # of restarts'),
               leading: const Icon(Icons.replay),
-              trailing: FittedBox(
-                fit: BoxFit.contain,
-                child: UnitNumberInput(
-                  controller: timeSettingsControllers['restarts']!,
-                  prefill: editing,
-                  enableMinutesToggle: false,
-                  valueRequired: false,
+              trailing: SizedBox(
+                width: 80,
+                child: TextFormField(
+                  controller: restartsController,
+                  decoration: inputDecoration,
+                  maxLength: 3,
+                  style: const TextStyle(fontSize: 30),
+                  textAlign: TextAlign.end,
+                  keyboardType: TextInputType.number,
                   onChanged: (value) {
-                    provider.setTimerTimeSettingPart(restarts: value);
+                    if (value.isEmpty) {
+                      provider.setTimerTimeSettingPart(restarts: 0);
+                    } else {
+                      provider.setTimerTimeSettingPart(restarts: int.tryParse(value) ?? 0);
+                    }
                     onEdited(StartSaveState.save);
                     Log.debug("Restarts time changed to $value");
 


### PR DESCRIPTION
## Description

restarts should show as unit-less number not as time (with seconds). Should only affect the UI.

## Motivation and Context

Resolves #300 

## How Has This Been Tested?

### Tested Platforms

* integration tests succeed on github
* Android 13, Google Pixel 4a
 
## Screenshots (optional)
<img width="100" alt="Screenshot_20260204-164520" src="https://github.com/user-attachments/assets/116235bd-f8c3-4338-8d08-7d8497be8804" />

## Types of changes

- [x] Chore (changes that do not affect docs or app behavior)
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update (changes to docs or screenshots)

## Checklist

- [x] I have read the Contributing guide: https://github.com/a-mabe/OpenHIIT/tree/main?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if needed)
- [x] I have made corresponding changes to the integration tests (if needed)
