### PR TITLE
feat: add configurable break sound

### DIFF
--- a/lib/core/db/database.dart
+++ b/lib/core/db/database.dart
@@ -6,7 +6,7 @@ import 'package:openhiit/core/db/tables.dart';
 import 'package:path/path.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
-int databaseVersion = 7; // Current database version
+int databaseVersion = 8; // Current database version
 
 class DatabaseManager {
   static const String _databaseName = "core1.db";

--- a/lib/core/db/migrations/migration_5.dart
+++ b/lib/core/db/migrations/migration_5.dart
@@ -1,0 +1,8 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+// migration_5
+// upgrade the database from version 6 to version 7
+Future<void> migration5(Database db) async {
+  await db
+      .execute("ALTER TABLE SoundSettingsTable ADD COLUMN breakSound TEXT;");
+}

--- a/lib/core/db/migrations/migration_5.dart
+++ b/lib/core/db/migrations/migration_5.dart
@@ -1,8 +1,0 @@
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
-
-// migration_5
-// upgrade the database from version 6 to version 7
-Future<void> migration5(Database db) async {
-  await db
-      .execute("ALTER TABLE SoundSettingsTable ADD COLUMN breakSound TEXT;");
-}

--- a/lib/core/db/migrations/migration_8.dart
+++ b/lib/core/db/migrations/migration_8.dart
@@ -1,0 +1,12 @@
+import 'package:openhiit/core/logs/logs.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<void> migration5(Database db) async {} // no-op
+Future<void> migration6(Database db) async {} // no-op
+Future<void> migration7(Database db) async {} // no-op
+Future<void> migration8(Database db) async {
+  Log.debug(
+      "Running migration 5: Adding breakSound column to SoundSettingsTable");
+  await db
+      .execute("ALTER TABLE SoundSettingsTable ADD COLUMN breakSound TEXT;");
+}

--- a/lib/core/db/migrations/migration_index.dart
+++ b/lib/core/db/migrations/migration_index.dart
@@ -1,10 +1,12 @@
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'migrations_1_to_4.dart';
+import 'migration_5.dart';
 
 final Map<int, Future<void> Function(Database db)> migrations = {
   1: migration1,
   2: migration2,
   3: migration3,
   4: migration4,
+  5: migration5,
 };

--- a/lib/core/db/migrations/migration_index.dart
+++ b/lib/core/db/migrations/migration_index.dart
@@ -1,7 +1,7 @@
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'migrations_1_to_4.dart';
-import 'migration_5.dart';
+import 'migration_8.dart';
 
 final Map<int, Future<void> Function(Database db)> migrations = {
   1: migration1,
@@ -9,4 +9,7 @@ final Map<int, Future<void> Function(Database db)> migrations = {
   3: migration3,
   4: migration4,
   5: migration5,
+  6: migration6,
+  7: migration7,
+  8: migration8,
 };

--- a/lib/core/db/migrations/migration_runner.dart
+++ b/lib/core/db/migrations/migration_runner.dart
@@ -8,7 +8,7 @@ Future<void> runMigrations(Database db, int oldVersion, int newVersion) async {
     Log.info("upgrading database from $oldVersion to $newVersion");
   }
 
-  for (int i = oldVersion; i < newVersion; i++) {
+  for (int i = oldVersion + 1; i <= newVersion; i++) {
     final migration = migrations[i];
     if (migration != null) {
       await migration(db);

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -81,6 +81,7 @@ const createSoundSettingsTableQuery = '''
         restSound TEXT,
         halfwaySound TEXT,
         endSound TEXT,
-        countdownSound TEXT
+        countdownSound TEXT,
+        breakSound TEXT
       )
     ''';

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -24,7 +24,6 @@ const createWorkoutTableQuery = '''
         halfwaySound TEXT,
         completeSound TEXT,
         countdownSound TEXT,
-        breakSound TEXT,
         colorInt INTEGER,
         workoutIndex INTEGER,
         showMinutes INTEGER

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -24,6 +24,7 @@ const createWorkoutTableQuery = '''
         halfwaySound TEXT,
         completeSound TEXT,
         countdownSound TEXT,
+        breakSound TEXT,
         colorInt INTEGER,
         workoutIndex INTEGER,
         showMinutes INTEGER

--- a/lib/core/models/timer_sound_settings.dart
+++ b/lib/core/models/timer_sound_settings.dart
@@ -28,7 +28,7 @@ class TimerSoundSettings {
         halfwaySound = "short-halfway-beep",
         endSound = "long-bell",
         countdownSound = "countdown-beep",
-        breakSound = "short-break-beep";
+        breakSound = "horn";
 
   TimerSoundSettings copyWith(
     Map<String, String> map, {

--- a/lib/core/models/timer_sound_settings.dart
+++ b/lib/core/models/timer_sound_settings.dart
@@ -8,6 +8,7 @@ class TimerSoundSettings {
   String halfwaySound;
   String endSound;
   String countdownSound;
+  String breakSound;
 
   TimerSoundSettings(
       {required this.id,
@@ -16,7 +17,8 @@ class TimerSoundSettings {
       required this.restSound,
       required this.halfwaySound,
       required this.endSound,
-      required this.countdownSound});
+      required this.countdownSound,
+      required this.breakSound});
 
   TimerSoundSettings.empty()
       : id = "",
@@ -25,7 +27,8 @@ class TimerSoundSettings {
         restSound = "short-rest-beep",
         halfwaySound = "short-halfway-beep",
         endSound = "long-bell",
-        countdownSound = "countdown-beep";
+        countdownSound = "countdown-beep",
+        breakSound = "short-break-beep";
 
   TimerSoundSettings copyWith(
     Map<String, String> map, {
@@ -39,6 +42,7 @@ class TimerSoundSettings {
       halfwaySound: updates?['halfwaySound'] ?? halfwaySound,
       endSound: updates?['endSound'] ?? endSound,
       countdownSound: updates?['countdownSound'] ?? countdownSound,
+      breakSound: updates?['breakSound'] ?? breakSound,
     );
   }
 
@@ -53,6 +57,7 @@ class TimerSoundSettings {
       halfwaySound: halfwaySound,
       endSound: endSound,
       countdownSound: countdownSound,
+      breakSound: breakSound,
     );
   }
 
@@ -65,6 +70,7 @@ class TimerSoundSettings {
       'halfwaySound': halfwaySound,
       'endSound': endSound,
       'countdownSound': countdownSound,
+      'breakSound': breakSound,
     };
   }
 
@@ -75,7 +81,8 @@ class TimerSoundSettings {
         restSound = map['restSound'] ?? "",
         halfwaySound = map['halfwaySound'] ?? "",
         endSound = map['endSound'] ?? "",
-        countdownSound = map['countdownSound'] ?? "";
+        countdownSound = map['countdownSound'] ?? "",
+        breakSound = map['breakSound'] ?? "";
 
   Map<String, dynamic> toJson() {
     return {
@@ -86,6 +93,7 @@ class TimerSoundSettings {
       'halfwaySound': halfwaySound,
       'endSound': endSound,
       'countdownSound': countdownSound,
+      'breakSound': breakSound,
     };
   }
 
@@ -98,11 +106,12 @@ class TimerSoundSettings {
       halfwaySound: json['halfwaySound'] ?? "",
       endSound: json['endSound'] ?? "",
       countdownSound: json['countdownSound'] ?? "",
+      breakSound: json['breakSound'] ?? "",
     );
   }
 
   @override
   String toString() {
-    return 'TimerSoundSettings{id: $id, timerId: $timerId, workSound: $workSound, restSound: $restSound, halfwaySound: $halfwaySound, endSound: $endSound, countdownSound: $countdownSound}';
+    return 'TimerSoundSettings{id: $id, timerId: $timerId, workSound: $workSound, restSound: $restSound, halfwaySound: $halfwaySound, endSound: $endSound, countdownSound: $countdownSound, breakSound: $breakSound}';
   }
 }

--- a/lib/core/providers/timer_creation_provider/timer_creation_provider.dart
+++ b/lib/core/providers/timer_creation_provider/timer_creation_provider.dart
@@ -119,6 +119,7 @@ class TimerCreationProvider extends ChangeNotifier {
       if (halfwaySound != null) 'halfwaySound': halfwaySound,
       if (endSound != null) 'endSound': endSound,
       if (countdownSound != null) 'countdownSound': countdownSound,
+      if (breakSound != null) 'breakSound': breakSound,
     });
     _timer = _timer.copyWith({
       'soundSettings': _timer.soundSettings,

--- a/lib/core/providers/timer_creation_provider/timer_creation_provider.dart
+++ b/lib/core/providers/timer_creation_provider/timer_creation_provider.dart
@@ -111,6 +111,7 @@ class TimerCreationProvider extends ChangeNotifier {
     String? halfwaySound,
     String? endSound,
     String? countdownSound,
+    String? breakSound,
   }) {
     _timer.soundSettings = _timer.soundSettings.copyWith({}, updates: {
       if (workSound != null) 'workSound': workSound,

--- a/lib/core/providers/timer_provider/migrations/migration_1.dart
+++ b/lib/core/providers/timer_provider/migrations/migration_1.dart
@@ -55,6 +55,7 @@ TimerType migrateToTimer(Workout workout, bool update) {
         countdownSound: workout.countdownSound.contains("none")
             ? ""
             : workout.countdownSound,
+        breakSound: workout.restSound.contains("none") ? "" : workout.restSound,
       ),
       color: workout.colorInt,
       intervals: totalIntervals,

--- a/lib/core/providers/timer_provider/migrations/migration_3.dart
+++ b/lib/core/providers/timer_provider/migrations/migration_3.dart
@@ -1,0 +1,41 @@
+import 'package:openhiit/core/db/repositories/timer_repository.dart';
+import 'package:openhiit/core/db/repositories/timer_sound_settings_repository.dart';
+import 'package:openhiit/core/db/repositories/timer_time_settings_repository.dart';
+import 'package:openhiit/core/logs/logs.dart';
+import 'package:openhiit/core/models/timer_type.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> breakSoundMigration(
+    List<TimerType> timers,
+    TimerRepository timerRepository,
+    TimerTimeSettingsRepository timerTimeSettingsRepository,
+    TimerSoundSettingsRepository timerSoundSettingsRepository) async {
+  final prefs = await SharedPreferences.getInstance();
+  bool hasRunWarmupMigration =
+      prefs.getBool('hasRunBreakSoundMigration') ?? false;
+
+  if (!hasRunWarmupMigration) {
+    Log.info("Running break sound migration...");
+
+    for (var timer in timers) {
+      // Grab sound settings from the timer
+      timer.soundSettings = (await timerSoundSettingsRepository
+          .getSoundSettingsByTimerId(timer.id))!;
+
+      timer.timeSettings = (await timerTimeSettingsRepository
+          .getTimeSettingsByTimerId(timer.id))!;
+
+      if (timer.timeSettings.breakTime > 0) {
+        // Update the break sound to match the rest sound if not already set
+        if (timer.soundSettings.breakSound.isEmpty) {
+          timer.soundSettings.breakSound = timer.soundSettings.restSound;
+          await timerSoundSettingsRepository
+              .updateSoundSettings(timer.soundSettings);
+        }
+      }
+    }
+    await prefs.setBool('hasRunBreakSoundMigration', true);
+  } else {
+    Log.info("Break sound migration already completed. Skipping...");
+  }
+}

--- a/lib/core/providers/timer_provider/migrations/migration_3.dart
+++ b/lib/core/providers/timer_provider/migrations/migration_3.dart
@@ -11,11 +11,13 @@ Future<void> breakSoundMigration(
     TimerTimeSettingsRepository timerTimeSettingsRepository,
     TimerSoundSettingsRepository timerSoundSettingsRepository) async {
   final prefs = await SharedPreferences.getInstance();
-  bool hasRunWarmupMigration =
+  bool hasRunBreakSoundMigration =
       prefs.getBool('hasRunBreakSoundMigration') ?? false;
 
-  if (!hasRunWarmupMigration) {
+  if (!hasRunBreakSoundMigration) {
     Log.info("Running break sound migration...");
+
+    Log.debug("Found ${timers.length} timers to migrate");
 
     for (var timer in timers) {
       Log.debug("Migrating timer: ${timer.name} (${timer.id})");

--- a/lib/core/providers/timer_provider/migrations/migration_3.dart
+++ b/lib/core/providers/timer_provider/migrations/migration_3.dart
@@ -18,6 +18,8 @@ Future<void> breakSoundMigration(
     Log.info("Running break sound migration...");
 
     for (var timer in timers) {
+      Log.debug("Migrating timer: ${timer.name} (${timer.id})");
+
       // Grab sound settings from the timer
       timer.soundSettings = (await timerSoundSettingsRepository
           .getSoundSettingsByTimerId(timer.id))!;
@@ -29,6 +31,13 @@ Future<void> breakSoundMigration(
         // Update the break sound to match the rest sound if not already set
         if (timer.soundSettings.breakSound.isEmpty) {
           timer.soundSettings.breakSound = timer.soundSettings.restSound;
+          await timerSoundSettingsRepository
+              .updateSoundSettings(timer.soundSettings);
+        }
+      } else {
+        // If break time is 0, set it to the default horn sound
+        if (timer.soundSettings.breakSound.isEmpty) {
+          timer.soundSettings.breakSound = "horn";
           await timerSoundSettingsRepository
               .updateSoundSettings(timer.soundSettings);
         }

--- a/lib/core/providers/timer_provider/timer_provider.dart
+++ b/lib/core/providers/timer_provider/timer_provider.dart
@@ -10,6 +10,7 @@ import 'package:openhiit/core/providers/interval_provider/interval_provider.dart
 import 'package:openhiit/core/providers/timer_provider/migrations/migration_1.dart';
 import 'package:openhiit/core/providers/timer_provider/migrations/migration_2.dart';
 import 'package:openhiit/core/models/timer_type.dart';
+import 'package:openhiit/core/providers/timer_provider/migrations/migration_3.dart';
 import 'package:openhiit/core/utils/interval_calculation.dart';
 import 'package:uuid/uuid.dart';
 
@@ -58,6 +59,14 @@ class TimerProvider extends ChangeNotifier {
         _intervalRepository,
         _timerRepository,
         _timerTimeSettingsRepository,
+      );
+
+      // Run break sound migration
+      await breakSoundMigration(
+        _timers,
+        _timerRepository,
+        _timerTimeSettingsRepository,
+        _timerSoundSettingsRepository,
       );
 
       // Load timers

--- a/lib/core/providers/timer_provider/timer_provider.dart
+++ b/lib/core/providers/timer_provider/timer_provider.dart
@@ -53,6 +53,10 @@ class TimerProvider extends ChangeNotifier {
         }
       }
 
+      // Load timers
+      _timers = await _timerRepository.getAllTimers();
+      _timers.sort((a, b) => a.timerIndex.compareTo(b.timerIndex));
+
       // Run warmup migration
       await warmupMigration(
         _timers,
@@ -69,9 +73,6 @@ class TimerProvider extends ChangeNotifier {
         _timerSoundSettingsRepository,
       );
 
-      // Load timers
-      _timers = await _timerRepository.getAllTimers();
-      _timers.sort((a, b) => a.timerIndex.compareTo(b.timerIndex));
       notifyListeners();
 
       return _timers;

--- a/lib/core/utils/interval_calculation.dart
+++ b/lib/core/utils/interval_calculation.dart
@@ -95,7 +95,9 @@ List<IntervalType> generateIntervalsFromTimer(TimerType timer,
         time: timer.timeSettings.breakTime > 0
             ? timer.timeSettings.breakTime
             : timer.timeSettings.restTime,
-        startSound: timer.soundSettings.restSound,
+        startSound: timer.timeSettings.breakTime > 0
+            ? timer.soundSettings.breakSound
+            : timer.soundSettings.restSound,
         countdownSound: timer.soundSettings.countdownSound,
       );
     }

--- a/lib/features/edit_timer/ui/edit_timer.dart
+++ b/lib/features/edit_timer/ui/edit_timer.dart
@@ -91,8 +91,7 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
     nameController.text = timer.name;
     activeIntervalsController.text =
         timer.activeIntervals == 0 ? '' : timer.activeIntervals.toString();
-    restartsController.text =
-        ts.restarts == 0 ? '' : ts.restarts.toString();
+    restartsController.text = ts.restarts == 0 ? '' : ts.restarts.toString();
 
     timeSettingsControllers = {
       'work': UnitNumberInputController(
@@ -188,7 +187,7 @@ class _EditTimerState extends State<EditTimer> with TickerProviderStateMixin {
     final timerCreation = context.read<TimerCreationProvider>();
     final timerProvider = context.read<TimerProvider>();
 
-    final intervals = await generateIntervalsFromTimer(timerCreation.timer);
+    final intervals = generateIntervalsFromTimer(timerCreation.timer);
 
     if (!mounted) return;
 

--- a/lib/features/edit_timer/ui/widgets/tabs/sound_tab/sound_tab.dart
+++ b/lib/features/edit_timer/ui/widgets/tabs/sound_tab/sound_tab.dart
@@ -114,14 +114,16 @@ class _SoundTabState extends State<SoundTab> {
               provider.setTimerSoundSettingPart(endSound: value),
         ),
         const SizedBox(height: 16),
-        _buildSoundDropdown(
-          keyName: "break-sound",
-          label: "Break Sound",
-          initialValue: provider.timer.soundSettings.breakSound,
-          onChanged: (value) =>
-              provider.setTimerSoundSettingPart(breakSound: value),
-        ),
-        SizedBox(height: 80),
+        if (provider.timer.timeSettings.breakTime > 0) ...[
+          _buildSoundDropdown(
+            keyName: "break-sound",
+            label: "Break Sound",
+            initialValue: provider.timer.soundSettings.breakSound,
+            onChanged: (value) =>
+                provider.setTimerSoundSettingPart(breakSound: value),
+          ),
+          const SizedBox(height: 80),
+        ]
       ],
     );
   }

--- a/lib/features/edit_timer/ui/widgets/tabs/sound_tab/sound_tab.dart
+++ b/lib/features/edit_timer/ui/widgets/tabs/sound_tab/sound_tab.dart
@@ -114,7 +114,8 @@ class _SoundTabState extends State<SoundTab> {
               provider.setTimerSoundSettingPart(endSound: value),
         ),
         const SizedBox(height: 16),
-        if (provider.timer.timeSettings.breakTime > 0) ...[
+        if (provider.timer.timeSettings.breakTime > 0 &&
+            provider.timer.timeSettings.restarts > 0) ...[
           _buildSoundDropdown(
             keyName: "break-sound",
             label: "Break Sound",

--- a/lib/features/edit_timer/ui/widgets/tabs/sound_tab/sound_tab.dart
+++ b/lib/features/edit_timer/ui/widgets/tabs/sound_tab/sound_tab.dart
@@ -113,6 +113,14 @@ class _SoundTabState extends State<SoundTab> {
           onChanged: (value) =>
               provider.setTimerSoundSettingPart(endSound: value),
         ),
+        const SizedBox(height: 16),
+        _buildSoundDropdown(
+          keyName: "break-sound",
+          label: "Break Sound",
+          initialValue: provider.timer.soundSettings.breakSound,
+          onChanged: (value) =>
+              provider.setTimerSoundSettingPart(breakSound: value),
+        ),
         SizedBox(height: 80),
       ],
     );


### PR DESCRIPTION
## Description
Adds break sound option. Sound plays at the start of the break interval to signify it is time to take a break. The sound at the end of the break is still the work sound as the next interval is work. All sounds on the edit timer page are for the start of their respective interval. Existing timers are migrated automatically, with `breakSound` defaulting
to the existing `restSound` value if a break time was set. Otherwise the default `breakSound` placeholder is the horn sound.

## Motivation and Context
Resolves #258

## How Has This Been Tested?
- [x] **Fresh install — create a new timer:** Set a break sound different from the rest sound, save, and run the timer. Confirm the break sound plays during break intervals and the rest sound plays during rest intervals.
- [x] **Fresh install — default break sound:** Create a new timer without changing the break sound dropdown. Verify a sensible default is selected and plays correctly.
- [x] **Fresh install — default break sound:** Create a new timer and set the break sound dropdown to "None". Verify no sound plays.
- [x] **Existing timer migration:** Install the build over a previous version that has saved timers. Open each migrated timer and confirm `breakSound` matches the old `restSound` value and plays correctly during breaks.
- [x] **Edit an existing migrated timer:** Change the break sound on a migrated timer, save, and re-run. Confirm the new break sound is used and persists after closing and reopening the app.
- [x] **Break sound dropdown UI:** Open the timer creation/edit screen and confirm the break sound dropdown renders, is scrollable, and shows all available sounds.
- [x] **Persistence across app restart:** Create a timer with a specific break sound, force-quit the app, reopen, and confirm the break sound value is still correct.
- [x] **Full interval flow:** Run a timer through multiple full cycles (work → break → work → break) and confirm the correct sounds play at each transition without overlap or cutoff.
- [x] **Same sound for break and rest:** Set break sound and rest sound to the same value and confirm the timer runs without errors.

### Tested Platforms
- Platform 1: iOS 16.3, Apple iPhone 12

## Screenshots (optional)

## Types of changes
- [ ] Chore (changes that do not affect docs or app behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs or screenshots)

## Checklist
- [x] I have read the Contributing guide: https://github.com/a-mabe/OpenHIIT/tree/main?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if needed)
- [x] I have made corresponding changes to the integration tests (if needed)

## Additional Notes
The DB migration sets `breakSound` equal to `restSound` for all pre-existing timers to preserve
prior behavior. Existing functionality is not changed.