### PR TITLE
fix: tablet portrait mode should not show all navigation/app bars

### DIFF
--- a/lib/features/home/ui/home.dart
+++ b/lib/features/home/ui/home.dart
@@ -111,7 +111,7 @@ class _ListTimersPageState extends State<ListTimersPage> {
             return Scaffold(
               extendBodyBehindAppBar: true,
               extendBody: true,
-              appBar: isTablet && isLandscape
+              appBar: isTablet
                   ? PreferredSize(
                       preferredSize: Size.fromHeight(40.0),
                       child: AppBar(

--- a/lib/features/home/ui/home.dart
+++ b/lib/features/home/ui/home.dart
@@ -119,7 +119,7 @@ class _ListTimersPageState extends State<ListTimersPage> {
                         elevation: 0,
                       ),
                     )
-                  : (!isLandscape ? ListTimersAppBar() : null),
+                  : (!isLandscape && !isTablet ? ListTimersAppBar() : null),
               body: isLandscape || isTablet
                   ? Row(
                       children: [
@@ -135,7 +135,7 @@ class _ListTimersPageState extends State<ListTimersPage> {
                   : SafeArea(
                       child: _buildTimerList(timers),
                     ),
-              bottomNavigationBar: !isLandscape
+              bottomNavigationBar: !isLandscape && !isTablet
                   ? SafeArea(
                       top: false,
                       child: _buildBottomNavBar(timers),


### PR DESCRIPTION
## Description

On tablets in portrait orientation, both the portrait and landscape navigation rails and appbars were shown. On tablets, only the Navrail should be shown on the lefthand size.

## Motivation and Context

Fixes display on tablets in portrait orientation.

## How Has This Been Tested?

Verified the screens on iPad and Pixel, portrait and landscape.

### Tested Platforms

Platform 1: Pixel 4a, Android 13
Platform 2: iPad, iOS 15

## Screenshots (optional)

### Before:

<img width="500" alt="IMG_0014" src="https://github.com/user-attachments/assets/84e2112c-5fb2-4610-95bf-0ccff26cb6eb" />

### After:

<img width="500" alt="IMG_0015" src="https://github.com/user-attachments/assets/15fad121-5fad-4bab-9ef3-e7ae380feac0" />

## Types of changes

<!-- Please check all that apply. -->

- [ ] Chore (changes that do not affect docs or app behavior)
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update (changes to docs or screenshots)

## Checklist

- [x] I have read the Contributing guide: https://github.com/a-mabe/OpenHIIT/tree/main?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] I have made corresponding changes to the integration tests (if needed)

## Additional Notes
*Add any other context about the pull request here.*