### PR TITLE
fix: fixes interval number when no get ready + warmup is set

### DIFF
--- a/lib/features/run_timer/widgets/functions/functions.dart
+++ b/lib/features/run_timer/widgets/functions/functions.dart
@@ -16,19 +16,24 @@ List<TimerListTileModel> listItems(
     TimerType timer, List<IntervalType> intervals) {
   List<TimerListTileModel> listItems = [];
 
-  int workIntervalIndex = ["Rest", "Get Ready", "Warmup", "Cooldown", "Break"]
-          .contains(intervals.first.name)
-      ? 0
-      : 1;
+  final excludedIntervalNames = {
+    "rest",
+    "get ready",
+    "warmup",
+    "cooldown",
+    "break",
+  };
+
+  int workIntervalIndex = 1;
   for (var interval in intervals) {
+    final isNonWork =
+        excludedIntervalNames.contains(interval.name.toLowerCase());
+
     listItems.add(
       TimerListTileModel(
         action: interval.name,
         showMinutes: timer.showMinutes,
-        interval: ["Rest", "Get ready", "Warmup", "Cooldown", "Break"]
-                .contains(interval.name)
-            ? 0
-            : workIntervalIndex++,
+        interval: isNonWork ? 0 : workIntervalIndex++,
         total: timer.activeIntervals,
         seconds: interval.time,
       ),


### PR DESCRIPTION
## Description

When a timer with a warmup time + no get ready was configured, the numbering for Work intervals would be off by 1.

## Motivation and Context

Resolves #348 

## How Has This Been Tested?

- Create timer with warmupTime > 0 and getreadyTime == 0.
- Run timer, check numbering for Work intervals.

### Tested Platforms

- Platform 1: Android 13, Pixel 4a

## Screenshots (optional)

<img width="340" height="659" alt="Screenshot 2026-05-09 at 3 44 35 PM" src="https://github.com/user-attachments/assets/5079de0b-3d6b-4d0a-84c5-f0443ad52840" />

## Types of changes

<!-- Please check all that apply. -->

- [ ] Chore (changes that do not affect docs or app behavior)
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update (changes to docs or screenshots)

## Checklist

- [x] I have read the Contributing guide: https://github.com/a-mabe/OpenHIIT/tree/main?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] I have made corresponding changes to the integration tests (if needed)

## Additional Notes
*Add any other context about the pull request here.*